### PR TITLE
Fix: fixed runtime issue on Windows

### DIFF
--- a/Example_Card_Calypso/src/main/UseCase12_PerformanceMeasurement_EmbeddedValidation/Main_PerformanceMeasurement_EmbeddedValidation_Pcsc.cpp
+++ b/Example_Card_Calypso/src/main/UseCase12_PerformanceMeasurement_EmbeddedValidation/Main_PerformanceMeasurement_EmbeddedValidation_Pcsc.cpp
@@ -144,8 +144,8 @@ int main()
 
     std::shared_ptr<CardSecuritySetting> cardSecuritySetting =
         CalypsoExtensionService::getInstance()->createCardSecuritySetting();
-    cardSecuritySetting->setControlSamResource(samReader, calypsoSam)
-                        .enableRatificationMechanism();
+    cardSecuritySetting->setControlSamResource(samReader, calypsoSam);
+    cardSecuritySetting->enableRatificationMechanism();
 
     while (true) {
         logger->info("%########################################################%\n", YELLOW, RESET);

--- a/Example_Card_Calypso/src/main/UseCase5_MultipleSession/Main_MultipleSession_Pcsc.cpp
+++ b/Example_Card_Calypso/src/main/UseCase5_MultipleSession/Main_MultipleSession_Pcsc.cpp
@@ -148,8 +148,8 @@ int main()
     /* Create security settings that reference the SAM */
     std::shared_ptr<CardSecuritySetting> cardSecuritySetting =
         CalypsoExtensionService::getInstance()->createCardSecuritySetting();
-    cardSecuritySetting->setControlSamResource(samReader, calypsoSam)
-                        .enableMultipleSession();
+    cardSecuritySetting->setControlSamResource(samReader, calypsoSam);
+    cardSecuritySetting->enableMultipleSession();
 
     /* Performs file reads using the card transaction manager in non-secure mode. */
     std::shared_ptr<CardTransactionManager> cardTransaction =

--- a/Example_Card_Calypso/src/main/UseCase6_VerifyPin/Main_VerifyPin_Pcsc.cpp
+++ b/Example_Card_Calypso/src/main/UseCase6_VerifyPin/Main_VerifyPin_Pcsc.cpp
@@ -155,8 +155,8 @@ int main()
     /* Create security settings that reference the SAM */
     std::shared_ptr<CardSecuritySetting> cardSecuritySetting =
         CalypsoExtensionService::getInstance()->createCardSecuritySetting();
-    cardSecuritySetting->setControlSamResource(samReader, calypsoSam)
-                        .setPinVerificationCipheringKey(
+    cardSecuritySetting->setControlSamResource(samReader, calypsoSam);
+    cardSecuritySetting->setPinVerificationCipheringKey(
                             CalypsoConstants::PIN_VERIFICATION_CIPHERING_KEY_KIF,
                             CalypsoConstants::PIN_VERIFICATION_CIPHERING_KEY_KVC);
 

--- a/Example_Card_Calypso/src/main/UseCase8_StoredValue_DebitInSession/Main_StoredValue_DebitInSession_Pcsc.cpp
+++ b/Example_Card_Calypso/src/main/UseCase8_StoredValue_DebitInSession/Main_StoredValue_DebitInSession_Pcsc.cpp
@@ -144,8 +144,8 @@ int main()
     /* Create security settings that reference the SAM */
     std::shared_ptr<CardSecuritySetting> cardSecuritySetting =
         CalypsoExtensionService::getInstance()->createCardSecuritySetting();
-    cardSecuritySetting->setControlSamResource(samReader, calypsoSam)
-                        .enableSvLoadAndDebitLog();
+    cardSecuritySetting->setControlSamResource(samReader, calypsoSam);
+    cardSecuritySetting->enableSvLoadAndDebitLog();
 
     /* Performs file reads using the card transaction manager in non-secure mode. */
     std::shared_ptr<CardTransactionManager> cardTransaction =

--- a/Example_Card_Calypso/src/main/UseCase9_ChangePin/Main_ChangePin_Pcsc.cpp
+++ b/Example_Card_Calypso/src/main/UseCase9_ChangePin/Main_ChangePin_Pcsc.cpp
@@ -144,11 +144,11 @@ int main()
     /* Create security settings that reference the SAM */
     std::shared_ptr<CardSecuritySetting> cardSecuritySetting =
         CalypsoExtensionService::getInstance()->createCardSecuritySetting();
-    cardSecuritySetting->setControlSamResource(samReader, calypsoSam)
-                        .setPinVerificationCipheringKey(
+    cardSecuritySetting->setControlSamResource(samReader, calypsoSam);
+    cardSecuritySetting->setPinVerificationCipheringKey(
                             CalypsoConstants::PIN_VERIFICATION_CIPHERING_KEY_KIF,
-                            CalypsoConstants::PIN_VERIFICATION_CIPHERING_KEY_KVC)
-                        .setPinModificationCipheringKey(
+                            CalypsoConstants::PIN_VERIFICATION_CIPHERING_KEY_KVC);
+    cardSecuritySetting->setPinModificationCipheringKey(
                             CalypsoConstants::PIN_MODIFICATION_CIPHERING_KEY_KIF,
                             CalypsoConstants::PIN_MODIFICATION_CIPHERING_KEY_KVC);
 


### PR DESCRIPTION
- Tried to remove the need for the use of std::reinterpret_pointer_cast by always using the most basic for of CommonSecuritySetting